### PR TITLE
Introduce Timer and use it in some places

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,7 +12,8 @@
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
-            "joakin/elm-canvas": "5.0.0"
+            "joakin/elm-canvas": "5.0.0",
+            "turboMaCk/any-dict": "2.6.0"
         },
         "indirect": {
             "elm/time": "1.0.0",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -7,13 +7,14 @@ import Canvas.Settings exposing (..)
 import Collision
 import Color
 import Config exposing (Config)
-import Html exposing (Html)
+import Html exposing (Html, del)
 import Json.Decode as Decode exposing (Decoder)
 import Obstacle exposing (Obstacle)
 import Player exposing (Player)
 import Random
 import Types.Buffer as Buffer exposing (Buffer)
 import Types.Canvas exposing (Canvas)
+import Types.Timer as Timer exposing (Timer)
 
 
 
@@ -74,18 +75,26 @@ type alias Model =
     , canvas : Canvas
     , tempo : Float
     , obstacleBuffer : Buffer Obstacle
+    , obstacleSpawnTimer : Timer
+    , spawnCount : Int
     }
 
 
 initialModel : Canvas -> Model
 initialModel canvas =
+    let
+        config =
+            Config.default
+    in
     { player = Player.init ( 50, canvas.height / 2 )
     , obstacles = []
     , state = Menu
-    , config = Config.default
+    , config = config
     , canvas = canvas
     , tempo = 1.0
     , obstacleBuffer = Buffer.empty .id
+    , obstacleSpawnTimer = Timer.init config.obstacleSpawnFrequency
+    , spawnCount = 0
     }
 
 
@@ -114,13 +123,25 @@ collidedWithObstacle obstacle model =
     { model | obstacleBuffer = Buffer.insert obstacle model.obstacleBuffer }
 
 
-tick : Float -> Model -> Model
+tick : Float -> Model -> ( Model, Cmd Msg )
 tick deltaTime model =
-    { model
+    let
+        ( obstacleTimer, cmd ) =
+            Timer.update deltaTime model.obstacleSpawnTimer
+                |> Maybe.map (\t -> ( t, Cmd.none ))
+                |> Maybe.withDefault
+                    ( Timer.init model.config.obstacleSpawnFrequency
+                    , newObstacle model.canvas (String.fromInt model.spawnCount)
+                    )
+    in
+    ( { model
         | player = Player.update model.canvas model.config deltaTime model.player
         , obstacles = List.filterMap (Obstacle.update deltaTime) model.obstacles
         , obstacleBuffer = Buffer.update deltaTime model.obstacleBuffer
-    }
+        , obstacleSpawnTimer = obstacleTimer
+      }
+    , cmd
+    )
 
 
 
@@ -210,7 +231,7 @@ update msg model =
                         ( model, Cmd.none )
 
         GeneratedObstacle obstacle ->
-            ( { model | obstacles = obstacle :: model.obstacles }
+            ( { model | obstacles = obstacle :: model.obstacles, spawnCount = model.spawnCount + 1 }
             , audioEvent "obstacleSpawned" model
             )
 
@@ -219,39 +240,22 @@ update msg model =
 -- Helper Functions
 
 
-spawnCount : Float -> Config -> Int
-spawnCount time { obstacleSpawnFrequency } =
-    truncate <| time / obstacleSpawnFrequency
-
-
 audioEvent : String -> Model -> Cmd msg
 audioEvent message model =
     audioMsg
         { message = message
         , tempo = model.tempo
-        , spawns =
-            spawnCount (timeElapsed model.state) model.config
+        , spawns = model.spawnCount
         }
 
 
-newObstacle : Canvas -> Config -> TimeElapsed -> Float -> Cmd Msg
-newObstacle canvas config t dt =
-    let
-        timeForNewObstacle =
-            spawnCount (t + dt) config
-                - spawnCount t config
-    in
-    if timeForNewObstacle > 0 then
-        Random.generate GeneratedObstacle <|
-            Obstacle.randomObstacle
-                (String.fromInt <| spawnCount (t + dt) config)
-                ( canvas.width, canvas.height / 2 )
-
-    else
-        Cmd.none
+newObstacle : Canvas -> String -> Cmd Msg
+newObstacle canvas id =
+    Random.generate GeneratedObstacle <|
+        Obstacle.randomObstacle id ( canvas.width, canvas.height / 2 )
 
 
-handleCollision : (Model -> Model) -> Model -> Obstacle -> ( Model, Cmd Msg )
+handleCollision : (Model -> ( Model, Cmd Msg )) -> Model -> Obstacle -> ( Model, Cmd Msg )
 handleCollision tickFn model obstacle =
     case obstacle.variant of
         Obstacle.Wall ->
@@ -260,15 +264,23 @@ handleCollision tickFn model obstacle =
             )
 
         Obstacle.TempoIncrease ->
-            ( model
-                |> (collidedWithObstacle obstacle >> increaseTempo >> tickFn)
-            , audioEvent "tempoIncrease" model
+            let
+                ( tickedModel, cmds ) =
+                    tickFn model
+            in
+            ( tickedModel
+                |> (collidedWithObstacle obstacle >> increaseTempo)
+            , Cmd.batch [ audioEvent "tempoIncrease" model, cmds ]
             )
 
         Obstacle.TempoDecrease ->
-            ( model
-                |> (collidedWithObstacle obstacle >> decreaseTempo >> tickFn)
-            , audioEvent "tempoDecrease" model
+            let
+                ( tickedModel, cmds ) =
+                    tickFn model
+            in
+            ( tickedModel
+                |> (collidedWithObstacle obstacle >> decreaseTempo)
+            , Cmd.batch [ audioEvent "tempoDecrease" model, cmds ]
             )
 
 
@@ -282,9 +294,7 @@ processFrame model deltaTime =
         |> List.head
         |> Maybe.map (handleCollision (tick deltaTime) updatedModel)
         |> Maybe.withDefault
-            ( tick deltaTime updatedModel
-            , newObstacle model.canvas model.config (timeElapsed model.state) deltaTime
-            )
+            (tick deltaTime updatedModel)
 
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -7,7 +7,7 @@ import Canvas.Settings exposing (..)
 import Collision
 import Color
 import Config exposing (Config)
-import Html exposing (Html, del)
+import Html exposing (Html)
 import Json.Decode as Decode exposing (Decoder)
 import Obstacle exposing (Obstacle)
 import Player exposing (Player)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -140,6 +140,7 @@ tick deltaTime model =
         , obstacleBuffer = Buffer.update deltaTime model.obstacleBuffer
         , obstacleSpawnTimer = obstacleTimer
       }
+        |> incrementTimeElapsed deltaTime
     , cmd
     )
 
@@ -286,15 +287,11 @@ handleCollision tickFn model obstacle =
 
 processFrame : Model -> Float -> ( Model, Cmd Msg )
 processFrame model deltaTime =
-    let
-        updatedModel =
-            incrementTimeElapsed deltaTime model
-    in
     List.filter (Collision.intersects model.player) model.obstacles
         |> List.head
-        |> Maybe.map (handleCollision (tick deltaTime) updatedModel)
+        |> Maybe.map (handleCollision (tick deltaTime) model)
         |> Maybe.withDefault
-            (tick deltaTime updatedModel)
+            (tick deltaTime model)
 
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -275,17 +275,14 @@ handleCollision tickFn model obstacle =
 processFrame : Model -> Float -> ( Model, Cmd Msg )
 processFrame model deltaTime =
     let
-        scaledDeltaTime =
-            deltaTime * 0.1
-
         updatedModel =
             incrementTimeElapsed deltaTime model
     in
     List.filter (Collision.intersects model.player) model.obstacles
         |> List.head
-        |> Maybe.map (handleCollision (tick scaledDeltaTime) updatedModel)
+        |> Maybe.map (handleCollision (tick deltaTime) updatedModel)
         |> Maybe.withDefault
-            ( tick scaledDeltaTime updatedModel
+            ( tick deltaTime updatedModel
             , newObstacle model.canvas model.config (timeElapsed model.state) deltaTime
             )
 

--- a/src/Obstacle.elm
+++ b/src/Obstacle.elm
@@ -56,7 +56,7 @@ update : Float -> Obstacle -> Maybe Obstacle
 update deltaTime obstacle =
     let
         newPosition =
-            Tuple.mapFirst (\x -> x - deltaTime * obstacleSpeed) obstacle.position
+            Tuple.mapFirst (\x -> x - deltaTime * obstacleSpeed * 0.1) obstacle.position
 
         updatedObstacle =
             { obstacle

--- a/src/Obstacle.elm
+++ b/src/Obstacle.elm
@@ -24,22 +24,25 @@ type alias Obstacle =
     , height : Float
     , hitbox : Hitbox
     , variant : Variant
+    , id : String
     }
 
 
-init : Point -> Variant -> Obstacle
-init point variant =
+init : String -> Point -> Variant -> Obstacle
+init id point variant =
     { position = point
     , width = 25
     , height = 25
     , hitbox = hitbox point 25 25
     , variant = variant
+    , id = id
     }
 
 
-randomObstacle : Point -> Generator Obstacle
-randomObstacle point =
-    Random.map2 init
+randomObstacle : String -> Point -> Generator Obstacle
+randomObstacle id point =
+    Random.map3 init
+        (Random.constant id)
         (Random.constant point)
         (Random.uniform Wall [ TempoIncrease, TempoDecrease ])
 

--- a/src/Player.elm
+++ b/src/Player.elm
@@ -52,7 +52,7 @@ update canvas config deltaTime player =
     { player
         | position = newPosition
         , hitbox = hitbox newPosition
-        , velocity = player.velocity + config.gravity
+        , velocity = player.velocity + (config.gravity * deltaTime * 0.1)
         , state =
             if Tuple.second newPosition == (canvas.height / 2) then
                 Running
@@ -64,7 +64,7 @@ update canvas config deltaTime player =
 
 jump : Player -> Player
 jump player =
-    { player | velocity = -25, state = Jumping }
+    { player | velocity = -40, state = Jumping }
 
 
 canJump : Player -> Bool

--- a/src/Player.elm
+++ b/src/Player.elm
@@ -46,7 +46,7 @@ update canvas config deltaTime player =
         newPosition =
             ( xPos
             , max ((canvas.height / 2) - 150) <|
-                (min (canvas.height / 2) <| yPos + (player.velocity * deltaTime))
+                (min (canvas.height / 2) <| yPos + (player.velocity * deltaTime * 0.1))
             )
     in
     { player

--- a/src/Types/Buffer.elm
+++ b/src/Types/Buffer.elm
@@ -1,0 +1,35 @@
+module Types.Buffer exposing (Buffer, empty, insert, update)
+
+import Dict.Any as AnyDict exposing (AnyDict)
+
+
+type alias Ref =
+    Float
+
+
+type Buffer a
+    = Buffer (AnyDict String a Ref)
+
+
+update : Float -> Buffer a -> Buffer a
+update deltaTime (Buffer dict) =
+    let
+        updateTimer : a -> Ref -> Maybe Ref
+        updateTimer _ r =
+            if (r - deltaTime) > 0 then
+                Just (r - deltaTime)
+
+            else
+                Nothing
+    in
+    Buffer <| AnyDict.filterMap updateTimer dict
+
+
+empty : (a -> String) -> Buffer a
+empty toString =
+    Buffer (AnyDict.empty toString)
+
+
+insert : a -> Buffer a -> Buffer a
+insert a (Buffer dict) =
+    Buffer <| AnyDict.insert a 500 dict

--- a/src/Types/Buffer.elm
+++ b/src/Types/Buffer.elm
@@ -1,26 +1,18 @@
 module Types.Buffer exposing (Buffer, empty, insert, update)
 
 import Dict.Any as AnyDict exposing (AnyDict)
-
-
-type alias Ref =
-    Float
+import Types.Timer as Timer exposing (Timer)
 
 
 type Buffer a
-    = Buffer (AnyDict String a Ref)
+    = Buffer (AnyDict String a Timer)
 
 
 update : Float -> Buffer a -> Buffer a
 update deltaTime (Buffer dict) =
     let
-        updateTimer : a -> Ref -> Maybe Ref
-        updateTimer _ r =
-            if (r - deltaTime) > 0 then
-                Just (r - deltaTime)
-
-            else
-                Nothing
+        updateTimer _ t =
+            Timer.update deltaTime t
     in
     Buffer <| AnyDict.filterMap updateTimer dict
 
@@ -32,4 +24,4 @@ empty toString =
 
 insert : a -> Buffer a -> Buffer a
 insert a (Buffer dict) =
-    Buffer <| AnyDict.insert a 500 dict
+    Buffer <| AnyDict.insert a (Timer.init 500) dict

--- a/src/Types/Timer.elm
+++ b/src/Types/Timer.elm
@@ -1,0 +1,19 @@
+module Types.Timer exposing (..)
+
+
+type Timer
+    = Timer Float
+
+
+init : Float -> Timer
+init timeOut =
+    Timer timeOut
+
+
+update : Float -> Timer -> Maybe Timer
+update deltaTime (Timer t) =
+    if (t - deltaTime) > 0 then
+        Just <| Timer (t - deltaTime)
+
+    else
+        Nothing


### PR DESCRIPTION
Fixes the bug that was triggering a collision with the same obstacle every subsequent frame by putting recently collided obstacles in a Buffer that will clear out after some time. Use obstacle spawnCount as the obstacle's Id to track it in the Buffer

Puts the obstacle spawn timer in a timer and remove all the craziness we were doing beforehand.

Fixes the bug where the player's jump height was being influenced by the tempo, the issue was we weren't scaling gravity by the tempo as well to keep the forces balanced.

Moved deltaTime scaling into `Player` and `Obstacle` update functions. Let's just stick with dealing with the deltaTime that's scaled by tempo.