### PR TITLE
Gameplay tuning

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,14 +75,14 @@ function bassNote(spawns, tempo) {
   bassVoice.triggerAttack(
     bass[spawns % 24],
     Tone.now(),
-    Math.min(0.2 * tempo, 0.5));
+    Math.min(0.5 * tempo, 0.8));
 }
 
 function melodyNote(spawns, tempo) {
   melodyVoice.triggerAttack(
     melody[spawns % 24],
     Tone.now(),
-    Math.min(0.2 * tempo, 0.5));
+    Math.min(0.4 * tempo, 0.7));
 }
 
 

--- a/main.js
+++ b/main.js
@@ -15,15 +15,14 @@ const app = Elm.Main.init({
 app.ports.audioMsg.subscribe(({ message, tempo, spawns }) => {
   switch (message) {
     case "gameStarted":
-      newGame();
+      // newGame();
       break;
 
     case "playerJumped":
       break;
 
     case "obstacleSpawned":
-      nextNote(spawns - 1, tempo)
-      console.log("ObstacleSpawned", spawns - 1)
+      nextNote(spawns, tempo)
       break;
 
     case "tempoIncrease":
@@ -49,9 +48,6 @@ const feedbackDelay = new Tone.FeedbackDelay("4n", 0.3);
 const autoPanner = new Tone.AutoPanner("4n").start();
 const bassVoice = initializeGameSynth()
 const melodyVoice = initializeGameSynth();
-
-
-
 
 const bass = [
   "B2", "F#3", "B3",
@@ -86,7 +82,7 @@ function melodyNote(spawns, tempo) {
   melodyVoice.triggerAttack(
     melody[spawns % 24],
     Tone.now(),
-    Math.min(0.3 * tempo, 0.5));
+    Math.min(0.2 * tempo, 0.5));
 }
 
 
@@ -132,10 +128,10 @@ function initializeGameSynth() {
   return instrument
 }
 
-function newGame() {
-  bassVoice.triggerAttack("A3", Tone.now(), 0.2);
-}
+// function newGame() {
+//   bassVoice.triggerAttack("A3", Tone.now(), 0.2);
+// }
 
-function gameOver() {
-  bassVoice.triggerAttack("C#2", Tone.now(), 0.3);
-}
+// function gameOver() {
+//   bassVoice.triggerAttack("C#2", Tone.now(), 0.3);
+// }

--- a/main.js
+++ b/main.js
@@ -15,7 +15,6 @@ const app = Elm.Main.init({
 app.ports.audioMsg.subscribe(({ message, tempo, spawns }) => {
   switch (message) {
     case "gameStarted":
-      // newGame();
       break;
 
     case "playerJumped":
@@ -33,7 +32,6 @@ app.ports.audioMsg.subscribe(({ message, tempo, spawns }) => {
 
 
     case "gameOver":
-      gameOver();
       break;
 
     default:
@@ -127,11 +125,3 @@ function initializeGameSynth() {
 
   return instrument
 }
-
-// function newGame() {
-//   bassVoice.triggerAttack("A3", Tone.now(), 0.2);
-// }
-
-// function gameOver() {
-//   bassVoice.triggerAttack("C#2", Tone.now(), 0.3);
-// }

--- a/src/Config.elm
+++ b/src/Config.elm
@@ -4,13 +4,11 @@ module Config exposing (Config, default)
 type alias Config =
     { gravity : Float
     , obstacleSpawnFrequency : Float
-    , tempoIncrement : Float
     }
 
 
 default : Config
 default =
-    { gravity = 2
-    , obstacleSpawnFrequency = 1000
-    , tempoIncrement = 0.0005
+    { gravity = 1.5
+    , obstacleSpawnFrequency = 900
     }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -100,12 +100,12 @@ initialModel canvas =
 
 increaseTempo : Model -> Model
 increaseTempo model =
-    { model | tempo = model.tempo * 1.05 }
+    { model | tempo = model.tempo * 1.02 }
 
 
 decreaseTempo : Model -> Model
 decreaseTempo model =
-    { model | tempo = model.tempo * 0.95 }
+    { model | tempo = model.tempo * 0.98 }
 
 
 incrementTimeElapsed : Float -> Model -> Model

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -261,11 +261,11 @@ newObstacle : Canvas -> Int -> Cmd Msg
 newObstacle canvas id =
     case modBy 2 id of
         0 ->
-            Random.generate GeneratedObstacle <| Obstacle.new (String.fromInt id) ( canvas.width, canvas.height / 2 ) Obstacle.Wall
+            Random.generate GeneratedObstacle <| Obstacle.new id ( canvas.width, canvas.height / 2 ) Obstacle.Wall
 
         1 ->
             Random.generate GeneratedObstacle <|
-                Obstacle.randomObstacle (String.fromInt id) ( canvas.width, canvas.height / 2 )
+                Obstacle.randomObstacle id ( canvas.width, canvas.height / 2 )
 
         _ ->
             Cmd.none

--- a/src/Obstacle.elm
+++ b/src/Obstacle.elm
@@ -53,7 +53,12 @@ randomObstacle id point =
     Random.map3 init
         (Random.constant id)
         (Random.constant point)
-        (Random.uniform Rest [ TempoIncrease, TempoDecrease ])
+        (Random.weighted
+            ( 1, Rest )
+            [ ( 3, TempoIncrease )
+            , ( 3, TempoDecrease )
+            ]
+        )
 
 
 hitbox : Point -> Float -> Float -> Hitbox

--- a/src/Obstacle.elm
+++ b/src/Obstacle.elm
@@ -1,4 +1,4 @@
-module Obstacle exposing (Obstacle, Variant(..), randomObstacle, update, view)
+module Obstacle exposing (Obstacle, Variant(..), new, randomObstacle, update, view)
 
 import Canvas exposing (Point, Renderable)
 import Canvas.Settings as Settings
@@ -16,6 +16,7 @@ type Variant
     = Wall
     | TempoIncrease
     | TempoDecrease
+    | Rest
 
 
 type alias Obstacle =
@@ -39,12 +40,20 @@ init id point variant =
     }
 
 
+new : String -> Point -> Variant -> Generator Obstacle
+new id point variant =
+    Random.map3 init
+        (Random.constant id)
+        (Random.constant point)
+        (Random.constant variant)
+
+
 randomObstacle : String -> Point -> Generator Obstacle
 randomObstacle id point =
     Random.map3 init
         (Random.constant id)
         (Random.constant point)
-        (Random.uniform Wall [ TempoIncrease, TempoDecrease ])
+        (Random.uniform Rest [ TempoIncrease, TempoDecrease ])
 
 
 hitbox : Point -> Float -> Float -> Hitbox
@@ -87,6 +96,9 @@ view obstacle =
 
         TempoDecrease ->
             viewRect Color.yellow obstacle
+
+        Rest ->
+            viewRect Color.black obstacle
 
 
 viewRect : Color -> Obstacle -> Renderable

--- a/src/Obstacle.elm
+++ b/src/Obstacle.elm
@@ -40,23 +40,27 @@ init id point variant =
     }
 
 
-new : String -> Point -> Variant -> Generator Obstacle
+new : Int -> Point -> Variant -> Generator Obstacle
 new id point variant =
     Random.map3 init
-        (Random.constant id)
+        (Random.constant <| String.fromInt id)
         (Random.constant point)
         (Random.constant variant)
 
 
-randomObstacle : String -> Point -> Generator Obstacle
-randomObstacle id point =
+randomObstacle : Int -> Point -> Generator Obstacle
+randomObstacle spawnCount point =
+    let
+        restRate =
+            toFloat (max (6 - (spawnCount // 12)) 1)
+    in
     Random.map3 init
-        (Random.constant id)
+        (Random.constant <| String.fromInt spawnCount)
         (Random.constant point)
         (Random.weighted
-            ( 1, Rest )
+            ( restRate, Rest )
             [ ( 3, TempoIncrease )
-            , ( 3, TempoDecrease )
+            , ( 1, TempoDecrease )
             ]
         )
 

--- a/src/Player.elm
+++ b/src/Player.elm
@@ -22,6 +22,11 @@ type PlayerState
     | Jumping
 
 
+jumpImpulse : Float
+jumpImpulse =
+    -35
+
+
 init : Point -> Player
 init point =
     { position = point
@@ -45,7 +50,7 @@ update canvas config deltaTime player =
 
         newPosition =
             ( xPos
-            , max ((canvas.height / 2) - 150) <|
+            , max ((canvas.height / 2) - 75) <|
                 (min (canvas.height / 2) <| yPos + (player.velocity * deltaTime * 0.1))
             )
     in
@@ -64,7 +69,7 @@ update canvas config deltaTime player =
 
 jump : Player -> Player
 jump player =
-    { player | velocity = -40, state = Jumping }
+    { player | velocity = jumpImpulse, state = Jumping }
 
 
 canJump : Player -> Bool


### PR DESCRIPTION
Introduces Rest blocks, trigger spawn audio but immediately removed on spawn.
Rest block frequency decrease as spawn count increases


Blocks spawn in sequence: Alternating Walls and one of [Rest | TempoIncrease | TempoDecrease|]

Lowers player jump impulse and effect of gravity

Lowers tempo block effect from +/- 5% to 2% to smooth out time changes.
